### PR TITLE
Add SQF minifier page

### DIFF
--- a/Components/Layout/NavMenu.razor
+++ b/Components/Layout/NavMenu.razor
@@ -25,6 +25,12 @@
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Weather
             </NavLink>
         </div>
+
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="minify">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Minify
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/Components/Pages/Minify.razor
+++ b/Components/Pages/Minify.razor
@@ -1,0 +1,31 @@
+@page "/minify"
+@rendermode InteractiveServer
+@using SQFMinier.Tools
+
+<PageTitle>Minify</PageTitle>
+
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-6 mb-2">
+            <textarea class="form-control minifier-box" readonly>@OutputCode</textarea>
+        </div>
+        <div class="col-md-6 mb-2">
+            <textarea class="form-control minifier-box" @bind="InputCode"></textarea>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col text-center">
+            <button class="btn btn-primary" @onclick="OnMinify">Minify</button>
+        </div>
+    </div>
+</div>
+
+@code {
+    private string InputCode = string.Empty;
+    private string OutputCode = string.Empty;
+
+    private void OnMinify()
+    {
+        OutputCode = SQFMinifier.MinifyString(InputCode);
+    }
+}

--- a/Components/Pages/Minify.razor.css
+++ b/Components/Pages/Minify.razor.css
@@ -1,0 +1,3 @@
+.minifier-box {
+    height: 70vh;
+}

--- a/Tools/SQFMinifier.cs
+++ b/Tools/SQFMinifier.cs
@@ -66,6 +66,17 @@ public class SQFMinifier
     }
 
     /// <summary>
+    ///     Minifies SQF code provided as a string.
+    /// </summary>
+    /// <param name="code">SQF code to minify.</param>
+    /// <returns>The minified code.</returns>
+    public static string MinifyString(string code)
+    {
+        if (code == null) throw new ArgumentNullException(nameof(code));
+        return MinifyCode(code);
+    }
+
+    /// <summary>
     ///     Minifies an SQF file, reading from inputPath and optionally writing to outputPath.
     /// </summary>
     /// <param name="inputPath">Path to the source SQF file.</param>


### PR DESCRIPTION
## Summary
- expose a `MinifyString` helper on `SQFMinifier`
- add a new `/minify` page with a pair of text areas and button
- show link to Minify page in the nav menu

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68453b0447108325878edb80bdd6050d